### PR TITLE
[MDS-18] Convert MDS file to Apache Arrow format file

### DIFF
--- a/bin/mds.sh
+++ b/bin/mds.sh
@@ -28,6 +28,9 @@ function java_exec() {
   local JAVA_CMD="$JAVA_HOME/bin/java"
   if [ ! -e $JAVA_CMD ]; then JAVA_CMD=java; fi
 
+  local HEAP_SIZE=${HEAP_SIZE:-256m}
+  local JAVA_OPTS=${JAVA_OPTS:-}
+
   local dn
   local lib_paths=($libdir/lib $libdir)
   lib_paths+=($(
@@ -41,7 +44,7 @@ function java_exec() {
   do
     class_paths="$class_paths:$dn/*"
   done
-  $JAVA_CMD -cp "$class_paths" jp.co.yahoo.dataplatform.mds.tools.MDSTool $*
+  $JAVA_CMD $JAVA_OPTS -Xmx$HEAP_SIZE -Xms$HEAP_SIZE -cp "$class_paths" jp.co.yahoo.dataplatform.mds.tools.MDSTool $*
 }
 
 function show_usage() {

--- a/etc/dependency_pom.xml.template
+++ b/etc/dependency_pom.xml.template
@@ -28,7 +28,7 @@
     <dependency>
       <groupId>org.apache.arrow</groupId>
       <artifactId>arrow-vector</artifactId>
-      <version>0.8.0</version>
+      <version>0.11.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -54,13 +54,16 @@
       <groupId>net.jpountz.lz4</groupId>
       <artifactId>lz4</artifactId>
       <version>1.2.0</version>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>com.github.luben</groupId>
       <artifactId>zstd-jni</artifactId>
       <version>1.3.3-3</version>
-      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-all</artifactId>
+      <version>4.1.17.Final</version>
     </dependency>
   </dependencies>
 

--- a/src/tools/pom.xml
+++ b/src/tools/pom.xml
@@ -39,6 +39,17 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>org.apache.arrow</groupId>
+      <artifactId>arrow-vector</artifactId>
+      <version>0.11.0</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-all</artifactId>
+      <version>4.1.17.Final</version>
+    </dependency>
+    <dependency>
       <groupId>jp.co.yahoo.dataplatform.mds</groupId>
       <artifactId>multiple-dimension-spread-common</artifactId>
       <version>${project.version}</version>
@@ -51,6 +62,11 @@
     <dependency>
       <groupId>jp.co.yahoo.dataplatform.mds</groupId>
       <artifactId>multiple-dimension-spread-hive</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>jp.co.yahoo.dataplatform.mds</groupId>
+      <artifactId>multiple-dimension-spread-arrow</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/src/tools/src/main/java/jp/co/yahoo/dataplatform/mds/tools/ConvertArrowFormatTool.java
+++ b/src/tools/src/main/java/jp/co/yahoo/dataplatform/mds/tools/ConvertArrowFormatTool.java
@@ -1,0 +1,196 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.co.yahoo.dataplatform.mds.tools;
+
+import java.io.File;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.channels.Channels;
+
+import org.apache.commons.cli.GnuParser;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.OptionBuilder;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.ParseException;
+import org.apache.commons.cli.HelpFormatter;
+
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.ValueVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.ipc.ArrowFileWriter;
+
+import jp.co.yahoo.dataplatform.config.Configuration;
+import jp.co.yahoo.dataplatform.mds.MDSReader;
+import jp.co.yahoo.dataplatform.mds.MDSArrowReader;
+
+public final class ConvertArrowFormatTool{
+
+  private ConvertArrowFormatTool(){}
+
+  public static Options createOptions( final String[] args ){
+
+    Option input = OptionBuilder.
+      withLongOpt("input").
+      withDescription("Input file path.  \"-\" standard input").
+      hasArg().
+      isRequired().
+      withArgName("input").
+      create( 'i' );
+
+    Option ppd = OptionBuilder.
+      withLongOpt("projection_pushdown").
+      withDescription("Use projection pushdown. Format:\"[ [ \"column1\" , \"[column1-child]\" , \"column1-child-child\" ] [ \"column2\" , ... ] ... ]\"").
+      hasArg().
+      withArgName("projection_pushdown").
+      create( 'p' );
+
+    Option expand = OptionBuilder.
+      withLongOpt("expand").
+      withDescription("Use expand function.").
+      hasArg().
+      withArgName("expand").
+      create( 'e' );
+
+    Option flatten = OptionBuilder.
+      withLongOpt("flatten").
+      withDescription("Use flatten function.").
+      hasArg().
+      withArgName("flatten").
+      create( 'x' );
+
+    Option output = OptionBuilder.
+      withLongOpt("output").
+      withDescription("output file path. \"-\" standard output").
+      hasArg().
+      isRequired().
+      withArgName("output").
+      create( 'o' );
+
+    Option help = OptionBuilder.
+      withLongOpt("help").
+      withDescription("help").
+      withArgName("help").
+      create( 'h' );
+
+    Options  options = new Options();
+
+    return options
+      .addOption( input )
+      .addOption( ppd )
+      .addOption( flatten )
+      .addOption( output )
+      .addOption( help );
+  }
+
+  public static void printHelp( final String[] args ){
+    HelpFormatter hf = new HelpFormatter();
+    hf.printHelp( "[options]" , createOptions( args ) );
+  }
+
+  public static int run( final String[] args ) throws IOException{
+    CommandLine cl;
+    try{
+      CommandLineParser clParser = new GnuParser();
+      cl = clParser.parse( createOptions( args ) , args );
+    }catch( ParseException e ){
+      printHelp( args );
+      throw new IOException( e );
+    }
+
+    if( cl.hasOption( "help" ) ){
+      printHelp( args );
+      return 0;
+    }
+
+    String input = cl.getOptionValue( "input" , null );
+    String output = cl.getOptionValue( "output" , null );
+    String ppd = cl.getOptionValue( "projection_pushdown" , null );
+    String flatten = cl.getOptionValue( "flatten" , null );
+    String expand = cl.getOptionValue( "expand" , null );
+
+    Configuration config = new Configuration();
+    if( ppd != null ){
+      config.set( "spread.reader.read.column.names" , ppd );
+    }
+
+    if( expand != null ){
+      config.set( "spread.reader.expand.column" , expand );
+    }
+
+    if( flatten != null ){
+      config.set( "spread.reader.flatten.column" , flatten );
+    }
+
+    MDSReader reader = new MDSReader();
+    InputStream in = FileUtil.fopen( input );
+    if( "-".equals( input ) ){
+      ByteArrayOutputStream bOut = new ByteArrayOutputStream();
+      byte[] buffer = new byte[1024*10];
+      int readLength = in.read( buffer );
+      long totalLength = readLength;
+      while( 0 <= readLength ){
+        bOut.write( buffer );
+        readLength = in.read( buffer );
+        totalLength += readLength;
+      }
+      in = new ByteArrayInputStream( bOut.toByteArray() );
+      reader.setNewStream( in , totalLength , config );
+    }
+    else{
+      File file = new File( input );
+      long fileLength = file.length();
+      reader.setNewStream( in , fileLength , config );
+    }
+
+    MDSArrowReader arrowReader = new MDSArrowReader( reader , config );
+    OutputStream out = FileUtil.create( output );
+    convert( arrowReader , out , config );
+
+    return 0;
+  }
+
+  public static void convert( final MDSArrowReader arrowReader , final OutputStream out , final Configuration config ) throws IOException{
+    ArrowFileWriter writer = null;
+    while( arrowReader.hasNext() ){
+      ValueVector vector = arrowReader.next();
+      if( writer == null ){
+        VectorSchemaRoot schema = new VectorSchemaRoot( (FieldVector)vector );
+        writer = new ArrowFileWriter( schema, null, Channels.newChannel( out ) );
+        writer.start();
+      }
+      writer.writeBatch();
+    }
+    if( writer != null ){
+      writer.end();
+      writer.close();
+    }
+    arrowReader.close();
+  }
+
+  public static void main( final String[] args ) throws IOException{
+    System.exit( run( args ) );
+  }
+
+}

--- a/src/tools/src/main/java/jp/co/yahoo/dataplatform/mds/tools/MDSTool.java
+++ b/src/tools/src/main/java/jp/co/yahoo/dataplatform/mds/tools/MDSTool.java
@@ -63,6 +63,9 @@ public final class MDSTool{
     else if( "merge".equals( command ) ){
       MergeTool.main( commandArgs );
     }
+    else if( "to_arrow".equals( command ) ){
+      ConvertArrowFormatTool.main( commandArgs );
+    }
     else if( "help".equals( command ) ){
       printHelp();
       System.exit( 0 );

--- a/src/tools/src/test/java/jp/co/yahoo/dataplatform/mds/tools/TestConvertArrowFormatTool.java
+++ b/src/tools/src/test/java/jp/co/yahoo/dataplatform/mds/tools/TestConvertArrowFormatTool.java
@@ -1,0 +1,142 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.co.yahoo.dataplatform.mds.tools;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.List;
+import java.nio.channels.Channels;
+import java.nio.channels.SeekableByteChannel;
+
+import org.testng.annotations.Test;
+import org.testng.annotations.DataProvider;
+
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.ipc.SeekableReadChannel;
+import org.apache.arrow.vector.ipc.ArrowFileReader;
+import org.apache.arrow.vector.ipc.message.ArrowBlock;
+
+import jp.co.yahoo.dataplatform.config.Configuration;
+
+import jp.co.yahoo.dataplatform.schema.objects.*;
+
+import jp.co.yahoo.dataplatform.mds.MDSWriter;
+import jp.co.yahoo.dataplatform.mds.MDSReader;
+import jp.co.yahoo.dataplatform.mds.MDSArrowReader;
+import jp.co.yahoo.dataplatform.mds.spread.Spread;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.assertFalse;
+
+public class TestConvertArrowFormatTool{
+
+  private byte[] createTestData() throws IOException{
+    // Spread
+    // | col1 | col2 | col3 |
+    // | 100  | aaa  | NULL |
+    // | 200  | NULL | BBB  |
+    // | 300  | NULL | CCC  |
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    Configuration config = new Configuration();
+    Spread s = new Spread();
+    try (MDSWriter writer = new MDSWriter(out, config)) {
+      Map<String, Object> d = new HashMap<String, Object>();
+      d.put( "col1" , new LongObj( 100 ) );
+      d.put( "col2" , new StringObj( "aaa" ) );
+      s.addRow( d );
+
+      d.clear();
+      d.put( "col1" , new LongObj( 200 ) );
+      d.put( "col3" , new StringObj( "BBB" ) );
+      s.addRow( d );
+
+      d.clear();
+      d.put( "col1" , new LongObj( 300 ) );
+      d.put( "col3" , new StringObj( "CCC" ) );
+      s.addRow( d );
+      writer.append(s);
+    }
+    return out.toByteArray();
+  }
+
+  @Test
+  public void T_convert_1() throws IOException{
+    byte[] mdsFile = createTestData();
+    InputStream in = new ByteArrayInputStream( mdsFile );
+    MDSReader reader = new MDSReader();
+    Configuration config = new Configuration();
+    reader.setNewStream( in , mdsFile.length , config );
+    MDSArrowReader arrowReader = new MDSArrowReader( reader , config );
+    File testFile = new File( "target/TestConvertArrowFormatTool_T_convert_1.mds" );
+    if( testFile.exists() ){
+      testFile.delete();
+    }
+    FileOutputStream out = new FileOutputStream( testFile );
+    ConvertArrowFormatTool.convert( arrowReader , out , config );
+
+    FileInputStream arrowIn = new FileInputStream( testFile ); 
+    ArrowFileReader ar = new ArrowFileReader( arrowIn.getChannel() , new RootAllocator( Integer.MAX_VALUE ) );
+    VectorSchemaRoot root  = ar.getVectorSchemaRoot();
+    ArrowBlock rbBlock = ar.getRecordBlocks().get(0);
+    ar.loadRecordBatch(rbBlock);
+    List<FieldVector> fieldVectorList = root.getFieldVectors();
+    Map<String,FieldVector> vectorMap = new HashMap<String,FieldVector>();
+    for( FieldVector v : fieldVectorList ){
+      vectorMap.put( v.getField().getName() , v );
+    }
+
+    assertTrue( vectorMap.containsKey( "col1" ) );
+    assertTrue( vectorMap.containsKey( "col2" ) );
+    assertTrue( vectorMap.containsKey( "col3" ) );
+
+    BigIntVector col1 = (BigIntVector)( vectorMap.get( "col1" ) );
+    VarCharVector col2 = (VarCharVector)( vectorMap.get( "col2" ) );
+    VarCharVector col3 = (VarCharVector)( vectorMap.get( "col3" ) );
+
+
+    assertEquals( col1.get(0) , 100L );
+    assertEquals( col1.get(1) , 200L );
+    assertEquals( col1.get(2) , 300L );
+
+    assertEquals( col2.getObject(0).toString() , "aaa" );
+    assertTrue( col2.isNull(1) );
+    assertTrue( col2.isNull(2) );
+
+    assertTrue( col3.isNull(0) );
+    assertEquals( col3.getObject(1).toString() , "BBB" );
+    assertEquals( col3.getObject(2).toString() , "CCC" );
+
+    testFile.delete();
+    ar.close();
+  }
+
+}


### PR DESCRIPTION
### What is the necessity of this update? What is updated?
For converting MDS file to Apache Arrow format and using it in other programming language.
Added "to_arrow" command to convert the MDS file specified by Tools to Apache Arrow.

In the "setup" command old version if Netty version is not specified.
For this reason, I changed it to specify the version explicitly.

### How did you do the test? (Not required for updating documents)
Unit test added.
It converts from MDS file to Apache Arrow format and checks whether the value is correct.