### PR TITLE
MDS-22 Add spotbugs plugin to reporting element to generate HTML report.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,8 @@
     <maven-surefire-report-plugin.version>${maven-surefire-plugin.version}</maven-surefire-report-plugin.version>
     <maven-clover2-plugin.version>4.0.6</maven-clover2-plugin.version>
     <buildtype>test</buildtype>
+    <spotbugs-maven-plugin.version>3.1.8</spotbugs-maven-plugin.version>
+    <spotbugs.version>3.1.9</spotbugs.version>
   </properties>
 
   <distributionManagement>
@@ -209,12 +211,12 @@
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
-        <version>3.1.8</version>
+        <version>${spotbugs-maven-plugin.version}</version>
         <dependencies>
           <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs</artifactId>
-            <version>3.1.9</version>
+            <version>${spotbugs.version}</version>
           </dependency>
         </dependencies>
       </plugin>
@@ -230,6 +232,11 @@
         <configuration>
           <dependencyLocationsEnabled>false</dependencyLocationsEnabled>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <version>${spotbugs-maven-plugin.version}</version>
       </plugin>
     </plugins>
   </reporting>


### PR DESCRIPTION
### What is the necessity of this update? What is updated?
We can generate HTML reports of spotbugs with this change.

### How did you do the test? (Not required for updating documents)
I confirmed that `mvn site` generates the HTML reports.