### PR TITLE
MDS-24 JIRA's link is not a dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Please send a blank e-mail to the following address.
 Please accept [Contributer licence agreement](https://gist.github.com/ydnjp/3095832f100d5c3d2592)
 when participating as a developer.
 
-We invite you to [JIRA](https://multiple-dimension-spread.atlassian.net) as a bug tracking,
+We invite you to [JIRA](https://multiple-dimension-spread.atlassian.net/projects/MDS) as a bug tracking,
 when you mentioned in the above Mailing list.
 
 


### PR DESCRIPTION
### What is the necessity of this update? What is updated?
Because it becomes the login screen with the current URL.

### How did you do the test? (Not required for updating documents)
