### PR TITLE
fix the caluculation of row size in the getIndexIntBuffer

### DIFF
--- a/src/common/src/main/java/jp/co/yahoo/dataplatform/mds/binary/maker/UnsafeOptimizeLongColumnBinaryMaker.java
+++ b/src/common/src/main/java/jp/co/yahoo/dataplatform/mds/binary/maker/UnsafeOptimizeLongColumnBinaryMaker.java
@@ -513,7 +513,7 @@ public class UnsafeOptimizeLongColumnBinaryMaker implements IColumnBinaryMaker{
        * TODO: calculation row size method may not clear, then it should be impremented.
        */
       int size = length / converter.getBaseBytes();
-      //int size = length / Integer.BYTES;
+
       IReadSupporter wrapBuffer = converter.toReadSupporter( buffer , start , length );
       IntBuffer result = IntBuffer.allocate( size );
       for( int i = 0 ; i < size ; i++ ){

--- a/src/common/src/main/java/jp/co/yahoo/dataplatform/mds/binary/maker/UnsafeOptimizeLongColumnBinaryMaker.java
+++ b/src/common/src/main/java/jp/co/yahoo/dataplatform/mds/binary/maker/UnsafeOptimizeLongColumnBinaryMaker.java
@@ -506,7 +506,14 @@ public class UnsafeOptimizeLongColumnBinaryMaker implements IColumnBinaryMaker{
 
     @Override
     public IntBuffer getIndexIntBuffer( final byte[] buffer , final int start , final int length , final ByteOrder order ) throws IOException{
-      int size = length / Integer.BYTES;
+
+      /*
+       * Althrough, getBaseBytes() of IntConverter0 returns zero,
+       * this class is not selected by the upper stream.
+       * TODO: calculation row size method may not clear, then it should be impremented.
+       */
+      int size = length / converter.getBaseBytes();
+      //int size = length / Integer.BYTES;
       IReadSupporter wrapBuffer = converter.toReadSupporter( buffer , start , length );
       IntBuffer result = IntBuffer.allocate( size );
       for( int i = 0 ; i < size ; i++ ){

--- a/src/common/src/main/java/jp/co/yahoo/dataplatform/mds/util/io/NumberToBinaryUtils.java
+++ b/src/common/src/main/java/jp/co/yahoo/dataplatform/mds/util/io/NumberToBinaryUtils.java
@@ -383,6 +383,8 @@ public final class NumberToBinaryUtils{
 
     int calcBinarySize( final int rows );
 
+    int getBaseBytes();
+
     IWriteSupporter toWriteSuppoter( final int rows , final byte[] buffer , final int start , final int length ) throws IOException;
 
     IReadSupporter toReadSupporter( final byte[] buffer , final int start , final int length ) throws IOException;
@@ -394,6 +396,11 @@ public final class NumberToBinaryUtils{
     @Override
     public int calcBinarySize( final int rows ){
       return rows * Integer.BYTES + HEADER_SIZE;
+    }
+
+    @Override
+    public int getBaseBytes() {
+      return Integer.BYTES;
     }
 
     @Override
@@ -429,6 +436,11 @@ public final class NumberToBinaryUtils{
       int byteLength = Byte.BYTES * rows;
       int shortLength = Short.BYTES * rows;
       return shortLength + byteLength + HEADER_SIZE;
+    }
+
+    @Override
+    public int getBaseBytes() {
+      return Byte.BYTES + Short.BYTES;
     }
 
     @Override
@@ -482,6 +494,11 @@ public final class NumberToBinaryUtils{
     }
 
     @Override
+    public int getBaseBytes() {
+      return Short.BYTES;
+    }
+
+    @Override
     public IWriteSupporter toWriteSuppoter( final int rows , final byte[] buffer , final int start , final int length ) throws IOException{
       int shortLength = Short.BYTES * rows;
 
@@ -522,6 +539,11 @@ public final class NumberToBinaryUtils{
     }
 
     @Override
+    public int getBaseBytes() {
+      return Byte.BYTES;
+    }
+
+    @Override
     public IWriteSupporter toWriteSuppoter( final int rows , final byte[] buffer , final int start , final int length ) throws IOException{
       int byteLength = Byte.BYTES * rows;
 
@@ -558,6 +580,11 @@ public final class NumberToBinaryUtils{
     @Override
     public int calcBinarySize( final int rows ){
       return HEADER_SIZE;
+    }
+
+    @Override
+    public int getBaseBytes() {
+      return 0;
     }
 
     @Override


### PR DESCRIPTION
### What is the necessity of this update? What is updated?
fix the caluculation of row size in the getIndexIntBuffer

### How did you do the test? (Not required for updating documents)
Tested in yosegi on the case that errors occurred, and confirmed that the case passed using fixed code.